### PR TITLE
Implement value_to_string on Field

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,2 @@
+Tim Heap <tim@timheap.me>
+Zach Rose <zrose@theblacktux.com>

--- a/enumchoicefield/fields.py
+++ b/enumchoicefield/fields.py
@@ -80,3 +80,6 @@ class EnumChoiceField(Field):
 
     def get_internal_type(self):
         return "CharField"
+
+    def value_to_string(self, obj):
+        return obj.name

--- a/enumchoicefield/fields.py
+++ b/enumchoicefield/fields.py
@@ -82,4 +82,5 @@ class EnumChoiceField(Field):
         return "CharField"
 
     def value_to_string(self, obj):
-        return obj.name
+        value = self.value_from_object(obj)
+        return '' if value is None else value.name

--- a/enumchoicefield/tests/test_field.py
+++ b/enumchoicefield/tests/test_field.py
@@ -67,6 +67,11 @@ class EnumTestCase(TestCase):
                 'enum_class': MyEnum,
                 'max_length': 3}))
 
+    def test_value_to_string(self):
+        model_field = ChoiceModel._meta.get_field('choice')
+        string = model_field.value_to_string(MyEnum.bar)
+        self.assertEqual(string, 'bar')
+
     def test_formfield(self):
         model_field = ChoiceModel._meta.get_field('choice')
         form_field = model_field.formfield()

--- a/enumchoicefield/tests/test_field.py
+++ b/enumchoicefield/tests/test_field.py
@@ -1,3 +1,6 @@
+import json
+
+from django.core import serializers
 from django.test import TestCase
 
 from enumchoicefield.forms import EnumField
@@ -69,8 +72,27 @@ class EnumTestCase(TestCase):
 
     def test_value_to_string(self):
         model_field = ChoiceModel._meta.get_field('choice')
-        string = model_field.value_to_string(MyEnum.bar)
-        self.assertEqual(string, 'bar')
+
+        self.assertEqual(
+            model_field.value_to_string(ChoiceModel(choice=MyEnum.bar)),
+            'bar')
+        self.assertEqual(
+            model_field.value_to_string(ChoiceModel(choice=None)),
+            '')
+
+    def test_seralize(self):
+        NullableChoiceModel.objects.create(choice=MyEnum.baz)
+        NullableChoiceModel.objects.create(choice=None)
+        serialized = serializers.serialize(
+            'json', NullableChoiceModel.objects.all())
+        self.assertEqual(
+            json.loads(serialized),
+            [
+                {"model": "tests.nullablechoicemodel", "pk": 1, "fields": {
+                    "choice": "baz"}},
+                {"model": "tests.nullablechoicemodel", "pk": 2, "fields": {
+                    "choice": None}},
+            ])
 
     def test_formfield(self):
         model_field = ChoiceModel._meta.get_field('choice')


### PR DESCRIPTION
Hi @timheap, it turns out that `value_to_string` is a method you can implement when subclassing Django Field. For ["non-protected" types](https://github.com/django/django/blob/master/django/utils/encoding.py#L44), it's the default way that Python serializes a field:

https://github.com/django/django/blob/master/django/core/serializers/python.py#L54

So implementing that method fixes #2. Hooray!